### PR TITLE
Introduce Plugin Groups For Loading Organization

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -57,8 +57,10 @@ export default class LazyPlugin extends Plugin {
     // the earliest load binding will be the first in the final list
     // If the delay is 0, we just immediately enable the plugin and return
     const loadGroup = groups[0]
+    const isActiveOnStartup = obsidian.enabledPlugins.has(pluginId)
+    const isRunning = obsidian.plugins?.[pluginId]?._loaded
     if (loadGroup.startupDelaySeconds == 0) {
-      await obsidian.enablePluginAndSave(pluginId)
+      if (!isActiveOnStartup && !isRunning) await obsidian.enablePluginAndSave(pluginId)
       return
     }
 
@@ -67,10 +69,7 @@ export default class LazyPlugin extends Plugin {
     // a new plugin was just installed). If we detect this, we quick disable
     // and re-enable the plugin so it doesn't load automatically on the next
     // time. Otherwise, we just need to wait out the startup delay
-    const isEnabled = obsidian.enabledPlugins.has(pluginId)
-    const isRunning = obsidian.plugins?.[pluginId]?._loaded
-    const currentlyActive = isEnabled && isRunning
-    if (currentlyActive) {
+    if (isActiveOnStartup) {
       await obsidian.disablePluginAndSave(pluginId)
       await obsidian.enablePlugin(pluginId)
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,8 +6,7 @@ import {
   LazySettings,
   LoadingMethod,
   SettingsTab,
-  PluginGroupSettings,
-  createDefaultGroups
+  createDefaultPluginGroups
 } from './settings'
 
 const lazyPluginId = require('../manifest.json').id
@@ -27,7 +26,6 @@ export default class LazyPlugin extends Plugin {
       .filter(plugin =>
         plugin.id !== lazyPluginId &&                  // Filter out the Lazy Loader plugin
         !(Platform.isMobile && plugin.isDesktopOnly))  // Filter out desktop-only plugins from mobile
-      // TODO: me - In a separate branch, enable mobile only plugins
       .sort((a, b) => a.name.localeCompare(b.name))
 
     await this.setInitialPluginsConfiguration()
@@ -146,7 +144,7 @@ export default class LazyPlugin extends Plugin {
     // If an existing configuration isn't found, we construct a default
     // mapping based on the default startup times
     this.settings.groups = Object.assign(
-      {}, createDefaultGroups(this.settings), this.settings.groups)
+      {}, createDefaultPluginGroups(this.settings), this.settings.groups)
   }
 
   async saveSettings() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,7 @@ export default class LazyPlugin extends Plugin {
   manifests: PluginManifest[]
   pendingTimeouts: NodeJS.Timeout[] = []
 
-  async onload() {
+  async onload () {
     await this.loadSettings()
 
     // Get the list of installed plugins
@@ -38,7 +38,7 @@ export default class LazyPlugin extends Plugin {
   /**
    * Configure and load a plugin based on its startup settings.
    */
-  async setPluginStartup(pluginId: string) {
+  async setPluginStartup (pluginId: string) {
     const obsidian = this.app.plugins
 
     const groups = this.getPluginsGroups(pluginId)
@@ -97,14 +97,13 @@ export default class LazyPlugin extends Plugin {
    * Get the startup type for a given pluginId, falling back to Obsidian's current
    * loading method (enabled/disabled) if no configuration is found for this plugin.
    */
-  getPluginStartup(pluginId: string): LoadingMethod {
-    return this.settings.plugins?.[pluginId]?.startupType
-      || this.settings.defaultStartupType
-      || (this.app.plugins.enabledPlugins.has(pluginId)
-        ? LoadingMethod.instant : LoadingMethod.disabled)
+  getPluginStartup (pluginId: string): LoadingMethod {
+    return this.settings.plugins?.[pluginId]?.startupType ||
+      this.settings.defaultStartupType ||
+      (this.app.plugins.enabledPlugins.has(pluginId) ? LoadingMethod.instant : LoadingMethod.disabled)
   }
 
-  getPluginsGroups(pluginId: string): string[] {
+  getPluginsGroups (pluginId: string): string[] {
     this.settings.plugins[pluginId].groupIds = Object.assign([],
       Object.values(LoadingMethod),
       this.settings.plugins[pluginId].groupIds);
@@ -113,17 +112,16 @@ export default class LazyPlugin extends Plugin {
 
   // List out all groups that this plugin should be auto-assigned to
   // This is only called when initializing a plugin's loading settings
-  getAutoAddGroups(pluginId: string): string[] {
+  getAutoAddGroups (pluginId: string): string[] {
     // Since we don't have a method for creating custom groups, we can just
     // keep this as assigning the current default option
     return [LoadingMethod[this.getPluginStartup(pluginId)]]
   }
 
-  async loadSettings() {
+  async loadSettings () {
     this.data = Object.assign({}, DEFAULT_SETTINGS, await this.loadData())
     // Object.assign only works 1 level deep, so need to clone the sub-level as well
-    this.data.desktop = Object.assign(
-      {}, DEFAULT_DEVICE_SETTINGS, this.data.desktop)
+    this.data.desktop = Object.assign({}, DEFAULT_DEVICE_SETTINGS, this.data.desktop)
 
     // If user has dual mobile/desktop settings enabled
     if (this.data.dualConfigs && Platform.isMobile) {
@@ -147,7 +145,7 @@ export default class LazyPlugin extends Plugin {
       {}, createDefaultPluginGroups(this.settings), this.settings.groups)
   }
 
-  async saveSettings() {
+  async saveSettings () {
     await this.saveData(this.data)
   }
 
@@ -156,7 +154,7 @@ export default class LazyPlugin extends Plugin {
    * for any new plugin in the future, depending on what default value is chosen in the
    * Settings page.
    */
-  async setInitialPluginsConfiguration() {
+  async setInitialPluginsConfiguration () {
     for (const plugin of this.manifests) {
       if (!this.settings.plugins?.[plugin.id]?.startupType) {
         // There is no existing setting for this plugin, so create one
@@ -168,7 +166,7 @@ export default class LazyPlugin extends Plugin {
   /**
    * Update an individual plugin's configuration in the settings file
    */
-  async updatePluginSettings(pluginId: string) {
+  async updatePluginSettings (pluginId: string) {
     const startupType = this.getPluginStartup(pluginId)
     this.settings.plugins[pluginId] = {
       startupType: startupType,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -8,15 +8,17 @@ export enum LoadingMethod {
   long = 'long'
 }
 
-// Change to store a nullable groupId. If not set, value is taken from manifest?
 export interface PluginSettings {
   startupType?: LoadingMethod;
   loadAfter?: string;
   groupIds?: string[]
 }
 
-// TODO: me - Might be better to have id for plugin => group mapping
-// As that is more easily supportable for backwards compatability
+// Settings to apply for all plugins that belong to this group
+// Though the list of member plugins can be specified by listing their ids
+// in this group, for backwards compatibility with `LoadingMethod`, group
+// membership is also stored inside the plugin's settings (as the loader
+// loops through the individual plugins).
 export interface PluginGroupSettings {
   enablePluginsDuringStartup: boolean;
   generateEnableDisableCommands: boolean;
@@ -41,7 +43,7 @@ export interface DeviceSettings {
 }
 
 // Default groups have their values from the device settings
-export function createDefaultPluginGroups(device: DeviceSettings): PluginGroupSettings[] {
+export function createDefaultPluginGroups (device: DeviceSettings): PluginGroupSettings[] {
   return [{
     enablePluginsDuringStartup: true,
     generateEnableDisableCommands: false,
@@ -91,7 +93,7 @@ export interface LazySettings {
 export const DEFAULT_SETTINGS: LazySettings = {
   dualConfigs: false,
   showConsoleLog: false,
-  desktop: DEFAULT_DEVICE_SETTINGS,
+  desktop: DEFAULT_DEVICE_SETTINGS
 }
 
 const LoadingMethods: { [key in LoadingMethod]: string } = {
@@ -109,8 +111,13 @@ export class SettingsTab extends PluginSettingTab {
   filterString: string | undefined
   containerEl: HTMLElement
   pluginListContainer: HTMLElement
-  // groupsListContainer: HTMLElement
   pluginSettings: { [pluginId: string]: PluginSettings } = {}
+  // Stubs for integrating plugin groups into the ui (w/ `buildGroupList`)
+  // This container should hold a ui for creating and listing plugin groups,
+  // somewhat similar to the current ui for individual plugins. For
+  // compatibility, this ui element should default to being hidden via
+  // switch/checkbox, pre-initialized with `createDefaultPluginGroups`
+  // groupsListContainer: HTMLElement
   // groupSettings: { [groupId: string]: PluginGroupSettings } = {}
 
   constructor (app: App, plugin: LazyPlugin) {
@@ -252,17 +259,11 @@ export class SettingsTab extends PluginSettingTab {
     // Add an element to contain the plugin list
     this.pluginListContainer = this.containerEl.createEl('div')
     this.buildPluginList()
-
-    // Add an element to contain the groups list
-    // This should default to hidden via switch
-    // With the "4 group" defaulting to show via switch
-    // this.groupsListContainer = this.containerEl.createEl('div')
-    // this.buildGroupList()
   }
 
   // Eventual building point for the UI controls necessary to support
   // groups as a plugin loading mechanism
-  buildGroupList() {
+  buildGroupList () {
     // this.groupsListContainer.textContent = ''
   }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -12,7 +12,7 @@ export enum LoadingMethod {
 export interface PluginSettings {
   startupType?: LoadingMethod;
   loadAfter?: string;
-  groupId?: string[]
+  groupIds?: string[]
 }
 
 // TODO: me - Might be better to have id for plugin => group mapping
@@ -20,9 +20,9 @@ export interface PluginSettings {
 export interface PluginGroupSettings {
   enablePluginsDuringStartup: boolean;
   generateEnableDisableCommands: boolean;
-  startupDelaySeconds?: number;
+  startupDelaySeconds: number;
   autoAddNewPlugins: boolean;
-  plugins: {};
+  plugins: string[];
 }
 
 // Settings per device (desktop/mobile)
@@ -47,25 +47,25 @@ export function createDefaultGroups(device: DeviceSettings): PluginGroupSettings
     generateEnableDisableCommands: false,
     startupDelaySeconds: 0,
     autoAddNewPlugins: device.defaultStartupType == LoadingMethod.disabled,
-    plugins: {}
+    plugins: []
   },{
     enablePluginsDuringStartup: true,
     generateEnableDisableCommands: false,
     startupDelaySeconds: device.shortDelaySeconds,
     autoAddNewPlugins: device.defaultStartupType == LoadingMethod.short,
-    plugins: {}
+    plugins: []
   },{
     enablePluginsDuringStartup: true,
     generateEnableDisableCommands: false,
     startupDelaySeconds: device.longDelaySeconds,
     autoAddNewPlugins: device.defaultStartupType == LoadingMethod.long,
-    plugins: {}
+    plugins: []
   },{
     enablePluginsDuringStartup: false,
     generateEnableDisableCommands: false,
     startupDelaySeconds: 0,
     autoAddNewPlugins: device.defaultStartupType == LoadingMethod.disabled,
-    plugins: {}
+    plugins: []
   }];
 }
 
@@ -109,17 +109,15 @@ export class SettingsTab extends PluginSettingTab {
   filterString: string | undefined
   containerEl: HTMLElement
   pluginListContainer: HTMLElement
-  groupsListContainer: HTMLElement
+  // groupsListContainer: HTMLElement
   pluginSettings: { [pluginId: string]: PluginSettings } = {}
-  groupSettings: { [groupId: string]: PluginGroupSettings } = {}
+  // groupSettings: { [groupId: string]: PluginGroupSettings } = {}
 
   constructor (app: App, plugin: LazyPlugin) {
     super(app, plugin)
     this.app = app
     this.lazyPlugin = plugin
     this.pluginSettings = this.lazyPlugin.settings.plugins
-    // TODO: me - Unsure of how to map groups
-    this.groupSettings = this.lazyPlugin.settings.groups
   }
 
   async display () {
@@ -256,15 +254,16 @@ export class SettingsTab extends PluginSettingTab {
     this.buildPluginList()
 
     // Add an element to contain the groups list
-    // TODO: me - This should default to being hidden by a switch
-    this.groupsListContainer = this.containerEl.createEl('div')
-    this.buildGroupList()
+    // This should default to hidden via switch
+    // With the "4 group" defaulting to show via switch
+    // this.groupsListContainer = this.containerEl.createEl('div')
+    // this.buildGroupList()
   }
 
+  // Eventual building point for the UI controls necessary to support
+  // groups as a plugin loading mechanism
   buildGroupList() {
-    this.groupsListContainer.textContent = ''
-    // TODO: need to add list of "something" similar to `PluginManifest`
-    this.lazyPlugin.groups.forEach(group => {});
+    // this.groupsListContainer.textContent = ''
   }
 
   buildPluginList () {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -41,7 +41,7 @@ export interface DeviceSettings {
 }
 
 // Default groups have their values from the device settings
-export function createDefaultGroups(device: DeviceSettings): PluginGroupSettings[] {
+export function createDefaultPluginGroups(device: DeviceSettings): PluginGroupSettings[] {
   return [{
     enablePluginsDuringStartup: true,
     generateEnableDisableCommands: false,


### PR DESCRIPTION
Integrates the concept of plugin "groups" from the old [Plugin Groups](https://github.com/Mocca101/obsidian-plugin-groups), rebasing the prior loading options into auto-generated groups. Reimplements the existing loading mechanism to use plugin groups for the purpose of enabling future extensibility via custom groups.

This **_does not_** include the addition of any settings/ui elements for creating and editing groups as creating a "usable UI" is not really my forte (let alone, one matching the existing design language). I'm also new to Obsidian plugin development and so these changes are not explicitly tested as my system is not setup for it at the moment (can do, just don't know yet if this is a one off).

### Summary:
- Introduce new settings object **PluginGroupSettings** which defines a customization point for plugin loading options
  - Groups can customize whether they are enabled by default on startup as well as the delay before loading
  - Also provides options supporting future directions, such as "generating enable/disable commands"
- Implements the existing loading methods ("Disabled", "Instant", "Short Delay", "Long Delay") as default plugin groups
- Maintains backwards compatibility by assigning plugins to groups based on their saved "loading method" setting (if not indicated from the save data)